### PR TITLE
bfs: add basic tests for buidQuery and transformProps

### DIFF
--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/plugin/transformProps.ts
@@ -58,9 +58,6 @@ export default function transformProps(chartProps: ChartProps) {
    */
   const { width, height, formData, queriesData, hooks } = chartProps;
   const {
-    boldText,
-    headerFontSize,
-    headerText,
     geomColumn,
     selectedChart: selectedChartString,
     chartSize,
@@ -98,9 +95,6 @@ export default function transformProps(chartProps: ChartProps) {
       __timestamp: new Date(item.__timestamp as number),
     })),
     // and now your control data, manipulated as needed, and passed through as props!
-    boldText,
-    headerFontSize,
-    headerText,
     geomColumn,
     selectedChart,
     chartConfigs,

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/types.ts
@@ -64,7 +64,6 @@ export type ChartConfig = FeatureCollection<
 >;
 
 interface CartodiagramPluginCustomizeProps {
-  headerText: string;
   geomColumn: string;
   selectedChart: string;
   chartConfigs: ChartConfig;

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/chartUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/chartUtil.tsx
@@ -110,6 +110,7 @@ export const createChartComponent = (
           selectedValues={selectedValues}
           formData={formData}
           legendData={legendData}
+          refs={{}}
         />
       );
       break;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds basic tests for buildQuery and transformProps. These show how the different registries have to be called in order to succeed.

