### PR TITLE
Setup for `superset_wfs_dialect` development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-superset-volumes: &superset-volumes
   - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
   - ./tests:/app/tests
+  - ../superset_wfs_dialect:/app/superset_wfs_dialect
 
 x-common-build: &common-build
   context: .
@@ -87,10 +88,14 @@ services:
     container_name: superset_app
     command: ["/app/docker/docker-bootstrap.sh", "app"]
     restart: unless-stopped
+    cap_add:
+      - SYS_PTRACE
     ports:
       - 8088:8088
       # When in cypress-mode ->
       - 8081:8081
+      # Open debug port
+      - 5678:5678
     extra_hosts:
       - "host.docker.internal:host-gateway"
     user: *superset-user
@@ -101,6 +106,7 @@ services:
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
       SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
+      DEBUGGER: "1"
 
   superset-websocket:
     container_name: superset_websocket

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -68,7 +68,12 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --with-threads --reload --debugger --host=0.0.0.0
+    if [ "$DEBUGGER" = "1" ]; then
+        echo "Starting with debugpy..."
+        python -m debugpy --listen 0.0.0.0:5678 -m flask run -p $PORT --with-threads --reload --debugger --host=0.0.0.0
+    else
+        flask run -p $PORT --with-threads --reload --debugger --host=0.0.0.0
+    fi
     ;;
   app-gunicorn)
     echo "Starting web app..."


### PR DESCRIPTION
This adds some requirements for the development with the `superset_wfs_dialect`.

It also requires some changes in uncommited files:

`/docker/.env-local`:
```
PYTHONPATH=/app/superset_wfs_dialect:/app/pythonpath:/app/docker/pythonpath_dev
#SUPERSET_LOAD_EXAMPLES=no
```

`/docker/requirements-local.txt`:
```
OWSLib @ git+https://github.com/geopython/OWSLib.git@master
sqlglot>=21.0.0
debugpy>=1.8.14
lxml>=5.4.0
```

Additionaly i added a `.vscode` folder int the parent folder of `superset` and `superset_wfs_dialect`. It contains the following `launch.json`:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Python: Remote Attach",
            "type": "debugpy",
            "request": "attach",
            "connect": {
                "host": "localhost",
                "port": 5678
            },
            "pathMappings": [
                {
                    "localRoot": "${workspaceFolder}/superset/superset",
                    "remoteRoot": "/app/superset"
                },
                {
                    "localRoot": "${workspaceFolder}/superset_wfs_dialect",
                    "remoteRoot": "/app/superset_wfs_dialect"
                }
            ],
            "justMyCode": false
        }
    ]
}
```

