### PR TITLE
fix(ter): reset clsPrefix for antd components of GeoStyler

### DIFF
--- a/superset-frontend/src/explore/components/controls/LayerConfigsControl/GeoStylerWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/LayerConfigsControl/GeoStylerWrapper.tsx
@@ -24,6 +24,7 @@
  */
 import { CardStyle } from 'geostyler/dist/Component/CardStyle/CardStyle';
 import React from 'react';
+import { ConfigProvider } from 'antd-v5';
 import { GeoStylerWrapperProps } from './types';
 
 export const GeoStylerWrapper: React.FC<GeoStylerWrapperProps> = ({
@@ -31,7 +32,15 @@ export const GeoStylerWrapper: React.FC<GeoStylerWrapperProps> = ({
   ...passThroughProps
 }) => (
   <div className={className}>
-    <CardStyle {...passThroughProps} />
+    {/*
+     We reset to the default class prefix since geostyler css relies on
+     the default antd prefix. This can probably be removed once
+     antd v4 is no longer supported and the prefix antd5 is not being
+     used anymore.
+    */}
+    <ConfigProvider prefixCls="ant">
+      <CardStyle {...passThroughProps} />
+    </ConfigProvider>
   </div>
 );
 


### PR DESCRIPTION
This fixes the css for geostyler by resetting the clsPrefix for antd components which is adjusted by superset while migrating from antd4 to antd5.
