### PR TITLE
fix(ter): resolve color collisions for cartodiagrams in dashboards

### DIFF
--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/constants.ts
@@ -29,3 +29,7 @@ export enum GeometryFormat {
   WKB = 'WKB',
   WKT = 'WKT',
 }
+
+// copy of
+// superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+export const NULL_STRING = '<NULL>';

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/plugin/transformProps.ts
@@ -37,6 +37,7 @@ export default function transformProps(chartProps: ChartProps) {
     minZoom,
     chartBackgroundColor,
     chartBackgroundBorderRadius,
+    sliceId,
   } = formData;
   const { setControlValue = () => {} } = hooks;
   const selectedChart = parseSelectedChart(selectedChartString);
@@ -49,6 +50,7 @@ export default function transformProps(chartProps: ChartProps) {
     geomFormat,
     chartProps,
     chartTransformer,
+    sliceId,
   );
 
   return {


### PR DESCRIPTION
This resolves color collisions for cartodiagrams in dashboards by calling the color handling singleton for all given labels before the singleton is called via transformProps by the underlying charts. Through this, we can ensure that a single color will not be used for different labels in charts within the same cartodiagram. Please note that this does not work in the explore view due to the current implementation of the color handler.

## Example

Given a configured pie chart that has the labels `foo` and `faz` on the first location, and the labels `boo` and `baz` on the second location, respectively.

**Working** Dashboard view (different labels have different colors)
![image](https://github.com/user-attachments/assets/ab436622-2665-4d70-b027-887ec061cba1)

**Not** working Explore view (different labels share the same color)
![image](https://github.com/user-attachments/assets/1bc6d300-6814-42fe-ba92-19399cb30361)

