### PR TITLE
ci: change image tag to 5.0.0-COMMIT_SHA

### DIFF
--- a/.github/workflows/terrestris-release.yml
+++ b/.github/workflows/terrestris-release.yml
@@ -29,7 +29,7 @@ jobs:
           file: Dockerfile
           target: lean
           tags: |
-            ghcr.io/${{ github.repository }}:5.0.0rc2-${{ github.sha }}
+            ghcr.io/${{ github.repository }}:5.0.0-${{ github.sha }}
             ghcr.io/${{ github.repository }}:latest
 
       - name: Logout from GitHub Container Registry


### PR DESCRIPTION
This changes the image tag from `5.0.0rc2-COMMIT_SHA` to `5.0.0-COMMIT_SHA`.