### PR TITLE
feat(ter): add autoplay support with play/pause button and time display in thematic map plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,8 @@ services:
     environment:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
       SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
-      DEBUGGER: "1"
+      # If set to "1", make sure debugpy is available via requirements-local.txt
+      DEBUGGER: "0"
 
   superset-websocket:
     container_name: superset_websocket

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/TimeSlider.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/TimeSlider.tsx
@@ -17,8 +17,16 @@
  * under the License.
  */
 import { DataRecord } from '@superset-ui/core';
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { Slider } from 'antd';
+import { styled } from '@superset-ui/core';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Slider, Button } from 'antd';
+import { CaretRightOutlined, PauseOutlined } from '@ant-design/icons';
 
 import { TimeSliderProps } from '../types';
 import {
@@ -27,6 +35,36 @@ import {
   getFirstMark,
   getLastMark,
 } from '../util/timesliderUtil';
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 32px;
+  margin-top: 12px;
+`;
+
+const StyledButton = styled(Button)`
+  margin-right: 8px;
+`;
+
+const SliderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: space-between;
+`;
+
+const StyledSlider = styled(Slider)`
+  margin: 0;
+  margin-left: 32px;
+`;
+
+const TimeDisplay = styled.div`
+  font-size: 12px;
+  text-align: left;
+  line-height: 1;
+  margin-left: 25px;
+`;
 
 export const TimeSlider: React.FC<TimeSliderProps> = props => {
   const {
@@ -43,8 +81,20 @@ export const TimeSlider: React.FC<TimeSliderProps> = props => {
     [data, timeColumn],
   );
 
+  const markKeys = useMemo(
+    () => Object.keys(marks).map(k => parseInt(k, 10)),
+    [marks],
+  );
   const minVal = useMemo(() => getFirstMark(marks), [marks]);
   const maxVal = useMemo(() => getLastMark(marks), [marks]);
+
+  const [currentValue, setCurrentValue] = useState<number>(
+    defaultValue && markKeys.includes(defaultValue)
+      ? defaultValue
+      : (markKeys[0] ?? Date.now()),
+  );
+  const [isPlaying, setIsPlaying] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const formatter = useCallback(
     (value: number) => {
@@ -55,30 +105,65 @@ export const TimeSlider: React.FC<TimeSliderProps> = props => {
     [timesliderTooltipFormat],
   );
 
+  const advanceSlider = useCallback(() => {
+    const currentIdx = markKeys.indexOf(currentValue);
+    const nextIdx = (currentIdx + 1) % markKeys.length;
+    const nextVal = markKeys[nextIdx];
+    setCurrentValue(nextVal);
+    onChange?.(nextVal);
+  }, [currentValue, markKeys, onChange]);
+
+  const togglePlay = () => setIsPlaying(prev => !prev);
+
   useEffect(() => {
-    if (!marks || !onChange) {
-      return;
+    if (isPlaying) {
+      intervalRef.current = setInterval(advanceSlider, 1000);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
     }
-    const markKeys = Object.keys(marks);
-    if (
-      defaultValue === undefined ||
-      !markKeys.includes(defaultValue.toString())
-    ) {
-      onChange(parseInt(markKeys[0], 10));
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isPlaying, advanceSlider]);
+
+  useEffect(() => {
+    if (defaultValue === undefined || !markKeys.includes(defaultValue)) {
+      const first = markKeys[0];
+      setCurrentValue(first);
+      onChange?.(first);
     }
-  }, [defaultValue, marks, onChange]);
+  }, [defaultValue, markKeys, onChange]);
+
+  const handleSliderChange = (val: number) => {
+    setCurrentValue(val);
+    onChange?.(val);
+  };
 
   return (
-    <Slider
-      min={minVal}
-      max={maxVal}
-      marks={marks}
-      step={null}
-      tipFormatter={formatter}
-      defaultValue={defaultValue}
-      onChange={onChange}
-      {...sliderProps}
-    />
+    <Wrapper>
+      <StyledButton
+        onClick={togglePlay}
+        icon={isPlaying ? <PauseOutlined /> : <CaretRightOutlined />}
+      />
+      <SliderContainer>
+        <StyledSlider
+          min={minVal}
+          max={maxVal}
+          marks={marks}
+          step={null}
+          tipFormatter={formatter}
+          value={currentValue}
+          onChange={handleSliderChange}
+          {...sliderProps}
+        />
+        <TimeDisplay>
+          {formatDate(new Date(currentValue), timesliderTooltipFormat)}
+        </TimeDisplay>
+      </SliderContainer>
+    </Wrapper>
   );
 };
 


### PR DESCRIPTION
### SUMMARY
This PR introduces an `isPlaying` state and play/pause toggle button in the Thematic Map Plugin. This is achieved by an `setInterval`-based autoplay logic advancing through available time values in 1-second steps. The autoplay wraps to the first timestamp after reaching the end.

In addition, the `DEBUGGER` default value in `docker-compose.yml` is set from "1" to "0", as this value would otherwise lead to an error without further action.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Peek 2025-07-08 12-51](https://github.com/user-attachments/assets/19d354a5-12d9-442a-9020-4841775e5763)

### TESTING INSTRUCTIONS
- open a dashboard or chart view using the ThematicMap plugin with a time based dataset
- click the play button to start autoplay; verify the slider advances every second
- confirm the current time value updates below the slider
- at the end of the timeline, ensure it wraps around to the first timestamp
- click pause to stop autoplay

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
