### PR TITLE
Add e2e-tests

### DIFF
--- a/e2e-tests-terrestris/requirements.txt
+++ b/e2e-tests-terrestris/requirements.txt
@@ -1,0 +1,2 @@
+playwright>=1.37.0
+pytest-playwright>=0.3.0

--- a/e2e-tests-terrestris/tests/conftest.py
+++ b/e2e-tests-terrestris/tests/conftest.py
@@ -1,0 +1,166 @@
+import pytest
+import os
+from playwright.sync_api import sync_playwright, expect
+
+
+URL = os.environ.get('TEST_URL', 'http://localhost:8088/')
+USERNAME = os.environ.get('TEST_USERNAME', 'admin')
+PASSWORD = os.environ.get('TEST_PASSWORD', 'admin')
+WFS = os.environ.get(
+    'TEST_WFS',
+    'wfs://geodienste.leipzig.de/l3/OpenData/wfs'
+    '?REQUEST=GetCapabilities&SERVICE=WFS'
+)
+
+
+@pytest.fixture(scope="session")
+def browser():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def page(browser):
+    context = browser.new_context()
+    page = context.new_page()
+    yield page
+    context.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def admin_login(page):
+    page.goto(URL)
+    expect(page).to_have_title('Superset')
+
+    page.locator('#username').fill(USERNAME)
+    page.locator('#password').fill(PASSWORD)
+    page.locator('input.btn.btn-primary.btn-block').click()
+    page.wait_for_load_state('networkidle')
+
+    assert 'welcome' in page.url, f'Expected "welcome" in URL, got {page.url}'
+
+
+def create_wfs_connection(page):
+    page.goto(URL + 'databaseview/list/')
+    page.wait_for_load_state('networkidle')
+
+    expect(page.locator('i.fa-plus')).to_be_visible()
+    page.locator('i.fa-plus').click()
+    page.wait_for_load_state('networkidle')
+    expect(page.locator('h4:has-text("Connect a database")')).to_be_visible()
+
+    # Fill in the WFS connection form and create the database
+    expect(page.locator('#rc_select_4')).to_be_visible()
+    page.locator('#rc_select_4').click()
+    page.locator('div[title="Other"]').click()
+    page.wait_for_load_state('networkidle')
+    expect(page.locator('[name="sqlalchemy_uri"]')).to_be_visible()
+    page.locator('[name="sqlalchemy_uri"]').fill(WFS)
+    page.get_by_text('Test connection').click()
+    expect(page.get_by_text('Connection looks good!')).to_be_visible()
+    page.wait_for_load_state('networkidle')
+    connect_button = page.locator('button.superset-button-primary').nth(1)
+    try:
+        expect(connect_button).to_be_visible(timeout=2000)
+        connect_button.click()
+    except Exception:
+        connect_button.scroll_into_view_if_needed()
+        expect(connect_button).to_be_visible()
+        connect_button.click()
+    try:
+        expect(page.get_by_text('Database connected')).to_be_visible()
+    except Exception:
+        expect(page.get_by_text('already exists')).to_be_visible()
+    page.wait_for_load_state('networkidle')
+
+    backend_cell = page.locator('table[role="table"] tbody tr td').nth(1)
+    assert "wfs" in backend_cell.inner_text()
+
+
+def delete_wfs_connection(page):
+    page.goto(URL + 'databaseview/list/')
+    page.wait_for_load_state('networkidle')
+
+    # Delete the database
+    page.locator('span[aria-label="trash"]').first.click()
+    page.wait_for_load_state('networkidle')
+    expect(page.get_by_text('Delete Database?')).to_be_visible()
+    page.locator('#delete').fill('DELETE')
+    page.locator('button:has-text("Delete")').click()
+    page.wait_for_load_state('networkidle')
+
+    expect(page.get_by_text('Deleted:')).to_be_visible()
+    expect(page.locator('span:has-text("Other")')).to_have_count(0)
+
+
+def create_dataset(page):
+    create_wfs_connection(page)
+
+    page.goto(URL + 'tablemodelview/list/')
+    page.wait_for_load_state('networkidle')
+
+    expect(page.locator('i.fa-plus')).to_be_visible()
+    page.locator('i.fa-plus').click()
+    page.wait_for_load_state('networkidle')
+    expect(page.get_by_text('New dataset')).to_be_visible()
+
+    expect(
+        page.locator(
+            'input[aria-label="Select database or type to search '
+            'databases"]'
+        )
+    ).to_be_visible()
+    page.locator(
+        'input[aria-label="Select database or type to search '
+        'databases"]'
+    ).click()
+    page.locator('div[backend="wfs"]').click()
+    page.wait_for_load_state('networkidle')
+
+    expect(
+        page.locator(
+            'input[aria-label="Select table or type to search tables"]'
+        )
+    ).to_be_visible()
+    page.locator(
+        'input[aria-label="Select table or type to search tables"]'
+    ).click()
+    page.locator('span[aria-label="table"]').first.click()
+    page.wait_for_load_state('networkidle')
+    try:
+        page.get_by_text('Create dataset and create chart').click()
+        page.wait_for_load_state('networkidle')
+        try:
+            expect(
+                page.get_by_text('Create a new chart')
+            ).to_be_visible(
+                timeout=2000
+            )
+        except Exception:
+            expect(
+                page.get_by_text('already exists')
+            ).to_be_visible(timeout=2000)
+    except Exception:
+        expect(
+            page.get_by_text('This table already has a dataset').first
+        ).to_be_visible(
+             timeout=2000
+        )
+
+
+def delete_dataset(page):
+    page.goto(URL + 'tablemodelview/list/')
+    page.wait_for_load_state('networkidle')
+
+    # Delete the database
+    page.locator('span[aria-label="trash"]').first.click()
+    page.wait_for_load_state('networkidle')
+    expect(page.get_by_text('Delete Dataset?')).to_be_visible()
+    page.locator('#delete').fill('DELETE')
+    page.locator('button:has-text("Delete")').click()
+    page.wait_for_load_state('networkidle')
+
+    expect(page.get_by_text('Deleted:')).to_be_visible()
+    expect(page.locator('span:has-text("Other")')).to_have_count(0)

--- a/e2e-tests-terrestris/tests/test_e2e_wfs_connection.py
+++ b/e2e-tests-terrestris/tests/test_e2e_wfs_connection.py
@@ -1,0 +1,29 @@
+from playwright.sync_api import expect
+from conftest import URL, create_wfs_connection, delete_wfs_connection
+
+
+def test_create_wfs_connection(page):
+    create_wfs_connection(page)
+    delete_wfs_connection(page)
+
+
+def test_wfs_connection_with_invalid_url(page):
+    page.goto(URL + 'databaseview/list/')
+    page.wait_for_load_state('networkidle')
+
+    expect(page.locator('i.fa-plus')).to_be_visible()
+    page.locator('i.fa-plus').click()
+    page.wait_for_load_state('networkidle')
+    expect(page.locator('h4:has-text("Connect a database")')).to_be_visible()
+
+    # Fill in the WFS connection form with an invalid URL
+    expect(page.locator('#rc_select_4')).to_be_visible()
+    page.locator('#rc_select_4').click()
+    page.locator('div[title="Other"]').click()
+    page.wait_for_load_state('networkidle')
+    expect(page.locator('[name="sqlalchemy_uri"]')).to_be_visible()
+    page.locator('[name="sqlalchemy_uri"]').fill('invalid_wfs_url')
+    page.get_by_text('Test connection').click()
+
+    # Expect an error message for invalid URL
+    expect(page.get_by_text('Invalid connection string')).to_be_visible()

--- a/e2e-tests-terrestris/tox.ini
+++ b/e2e-tests-terrestris/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py
+skipsdist = True
+isolated_build = False
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    -rrequirements.txt
+passenv = *
+commands_pre =
+    python -m playwright install --with-deps
+commands =
+    pytest tests --cov=superset --cov-report=xml --cov-config=tox.ini --cov-branch
+
+[coverage:run]
+relative_files = True
+source = e2e-tests-terrestris/
+branch = True


### PR DESCRIPTION
This adds the setup for e2e-tests running with playwright and pytest. 

Tests can be run with:
`cd e2e-tests-terrestris`
`python -m venv venv`
`source venv/bin/activate`
`pip install tox`
` tox`

Additionally, the follwoing environment variables need to be defined before running tox:
- TEST_URL
- TEST_USERNAME
- TEST_PASSWORD
- WFS

