### PR TITLE
Add default value for groupBy

### DIFF
--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
@@ -426,7 +426,7 @@ export const reserveLabelColors = (
 ) => {
   // Call color singleton to reserve label colors
   // get needed control values from underlying chart config
-  const { colorScheme = '', groupby, dateFormat } = formData;
+  const { colorScheme = '', groupby = [], dateFormat } = formData;
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
   const groupbyLabels = groupby.map(getColumnLabel);
   Object.keys(dataByLocation).forEach(location => {


### PR DESCRIPTION
This adds an empty array as default value for the `groupby` property of `formData`.

This allows using BigNumber charts as resource for cartodiagramms.