### PR TITLE
Optimize cartodiagram WKB/WKT polygon feature handling

### DIFF
--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecord } from '@superset-ui/core';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Feature, FeatureCollection } from 'geojson';
 import { debounce, xor, uniq } from 'lodash';
@@ -31,6 +31,7 @@ import VectorSource from 'ol/source/Vector';
 import GeoJSON from 'ol/format/GeoJSON';
 import {
   dataRecordsToOlFeatures,
+  fitMapToFeatures,
   fitMapToData,
   fitMapToDataRecords,
 } from '../../util/mapUtil';
@@ -107,6 +108,20 @@ export const OlChartMap = (props: OlChartMapProps) => {
     }
     return data;
   }, [data, geomColumn, geomFormat]);
+
+  const dataFeatures = useMemo(() => {
+    if (
+      geomFormat === GeometryFormat.WKB ||
+      geomFormat === GeometryFormat.WKT
+    ) {
+      return dataRecordsToOlFeatures(
+        processedData as DataRecord[],
+        geomColumn,
+        geomFormat,
+      ) as OlFeature[];
+    }
+    return undefined;
+  }, [processedData, geomColumn, geomFormat]);
 
   /**
    * Add map to correct DOM element.
@@ -203,13 +218,21 @@ export const OlChartMap = (props: OlChartMapProps) => {
           geomFormat === GeometryFormat.WKB ||
           geomFormat === GeometryFormat.WKT
         ) {
-          fitMapToDataRecords(
-            olMap,
-            processedData as DataRecord[],
-            geomColumn,
-            geomFormat,
-            getMapExtentPadding(mapExtentPadding),
-          );
+          if (dataFeatures) {
+            fitMapToFeatures(
+              olMap,
+              dataFeatures,
+              getMapExtentPadding(mapExtentPadding),
+            );
+          } else {
+            fitMapToDataRecords(
+              olMap,
+              processedData as DataRecord[],
+              geomColumn,
+              geomFormat,
+              getMapExtentPadding(mapExtentPadding),
+            );
+          }
         } else {
           fitMapToData(
             olMap,
@@ -311,13 +334,21 @@ export const OlChartMap = (props: OlChartMapProps) => {
         geomFormat === GeometryFormat.WKB ||
         geomFormat === GeometryFormat.WKT
       ) {
-        fitMapToDataRecords(
-          olMap,
-          data,
-          geomColumn,
-          geomFormat,
-          getMapExtentPadding(mapExtentPadding),
-        );
+        if (dataFeatures) {
+          fitMapToFeatures(
+            olMap,
+            dataFeatures,
+            getMapExtentPadding(mapExtentPadding),
+          );
+        } else {
+          fitMapToDataRecords(
+            olMap,
+            data,
+            geomColumn,
+            geomFormat,
+            getMapExtentPadding(mapExtentPadding),
+          );
+        }
       } else {
         fitMapToData(
           olMap,
@@ -333,6 +364,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
     geomFormat,
     geomColumn,
     processedData,
+    dataFeatures,
     mapExtentPadding,
   ]);
 
@@ -368,6 +400,23 @@ export const OlChartMap = (props: OlChartMapProps) => {
     }
     return filteredRecords;
   }, [processedData, timeColumn, timeFilter, geomFormat]);
+
+  const filteredFeatures = useMemo(() => {
+    if (
+      geomFormat === GeometryFormat.WKB ||
+      geomFormat === GeometryFormat.WKT
+    ) {
+      if (filteredData === processedData) {
+        return dataFeatures;
+      }
+      return dataRecordsToOlFeatures(
+        filteredData as DataRecord[],
+        geomColumn,
+        geomFormat,
+      ) as OlFeature[];
+    }
+    return undefined;
+  }, [filteredData, processedData, dataFeatures, geomColumn, geomFormat]);
 
   /**
    * Update layers
@@ -411,11 +460,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
         geomFormat === GeometryFormat.WKB ||
         geomFormat === GeometryFormat.WKT
       ) {
-        features = dataRecordsToOlFeatures(
-          filteredData as DataRecord[],
-          geomColumn,
-          geomFormat,
-        ) as OlFeature[];
+        features = (filteredFeatures || []) as OlFeature[];
       } else {
         features = new GeoJSON().readFeatures(filteredData, {
           featureProjection: 'EPSG:3857',
@@ -424,7 +469,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
       source?.clear();
       source?.addFeatures(features);
     });
-  }, [currentDataLayers, filteredData, geomColumn, geomFormat]);
+  }, [currentDataLayers, filteredData, filteredFeatures, geomColumn, geomFormat]);
 
   useEffect(() => {
     removeSelectionLayer(olMap);

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecord } from '@superset-ui/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Feature, FeatureCollection } from 'geojson';
 import { debounce, xor, uniq } from 'lodash';
@@ -33,7 +33,6 @@ import {
   dataRecordsToOlFeatures,
   fitMapToFeatures,
   fitMapToData,
-  fitMapToDataRecords,
 } from '../../util/mapUtil';
 import {
   createLayer,
@@ -109,6 +108,11 @@ export const OlChartMap = (props: OlChartMapProps) => {
     return data;
   }, [data, geomColumn, geomFormat]);
 
+  /**
+   * Use OL features for WKB/WKT-specific flows that need native OpenLayers
+   * features repeatedly, such as extent fitting and vector source updates.
+   * Keep using processedData for filtering and GeoJSON-backed logic.
+   */
   const dataFeatures = useMemo(() => {
     if (
       geomFormat === GeometryFormat.WKB ||
@@ -218,21 +222,11 @@ export const OlChartMap = (props: OlChartMapProps) => {
           geomFormat === GeometryFormat.WKB ||
           geomFormat === GeometryFormat.WKT
         ) {
-          if (dataFeatures) {
-            fitMapToFeatures(
-              olMap,
-              dataFeatures,
-              getMapExtentPadding(mapExtentPadding),
-            );
-          } else {
-            fitMapToDataRecords(
-              olMap,
-              processedData as DataRecord[],
-              geomColumn,
-              geomFormat,
-              getMapExtentPadding(mapExtentPadding),
-            );
-          }
+          fitMapToFeatures(
+            olMap,
+            dataFeatures || [],
+            getMapExtentPadding(mapExtentPadding),
+          );
         } else {
           fitMapToData(
             olMap,
@@ -334,21 +328,11 @@ export const OlChartMap = (props: OlChartMapProps) => {
         geomFormat === GeometryFormat.WKB ||
         geomFormat === GeometryFormat.WKT
       ) {
-        if (dataFeatures) {
-          fitMapToFeatures(
-            olMap,
-            dataFeatures,
-            getMapExtentPadding(mapExtentPadding),
-          );
-        } else {
-          fitMapToDataRecords(
-            olMap,
-            data,
-            geomColumn,
-            geomFormat,
-            getMapExtentPadding(mapExtentPadding),
-          );
-        }
+        fitMapToFeatures(
+          olMap,
+          dataFeatures || [],
+          getMapExtentPadding(mapExtentPadding),
+        );
       } else {
         fitMapToData(
           olMap,
@@ -469,7 +453,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
       source?.clear();
       source?.addFeatures(features);
     });
-  }, [currentDataLayers, filteredData, filteredFeatures, geomColumn, geomFormat]);
+  }, [currentDataLayers, filteredData, filteredFeatures, geomFormat]);
 
   useEffect(() => {
     removeSelectionLayer(olMap);

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/mapUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/mapUtil.tsx
@@ -72,6 +72,14 @@ const fitToData = (
   }
 };
 
+export const fitMapToFeatures = (
+  olMap: Map,
+  features: Feature[],
+  padding?: FitOptions['padding'] | undefined,
+) => {
+  fitToData(olMap, features, padding);
+};
+
 const extractSridFromWkt = (wkt: string) => {
   const extract: { geom: string; srid: string | null } = {
     geom: wkt,
@@ -127,35 +135,35 @@ export const dataRecordsToOlFeatures = (
   geomColumn: string,
   geomFormat: GeometryFormat.WKB | GeometryFormat.WKT,
 ) => {
-  let format: WKB | WKT = new WKB();
+  const format: WKB | WKT = geomFormat === GeometryFormat.WKT ? new WKT() : new WKB();
+  const features: Feature[] = [];
+  const defaultOpts: any = { featureProjection: 'EPSG:3857' };
+  const defaultWktOpts: any = {
+    featureProjection: 'EPSG:3857',
+    dataProjection: 'EPSG:4326',
+  };
 
-  if (geomFormat === GeometryFormat.WKT) {
-    format = new WKT();
+  for (let i = 0; i < dataRecords.length; i += 1) {
+    const item = dataRecords[i];
+    const geom = item[geomColumn];
+    if (typeof geom !== 'string') continue;
+
+    let cleanedGeom = geom;
+    let opts = defaultOpts;
+    if (geomFormat === GeometryFormat.WKT) {
+      const extract = extractSridFromWkt(geom);
+      cleanedGeom = extract.geom;
+      opts = extract.srid
+        ? { featureProjection: 'EPSG:3857', dataProjection: extract.srid }
+        : defaultWktOpts;
+    }
+
+    const feature = format.readFeature(cleanedGeom, opts);
+
+    feature.setProperties(item);
+
+    features.push(feature);
   }
-  const features = dataRecords
-    .map(item => {
-      const geom = item[geomColumn];
-      if (typeof geom !== 'string') {
-        return undefined;
-      }
-
-      let cleanedGeom = geom;
-      const opts: any = {
-        featureProjection: 'EPSG:3857',
-      };
-      if (geomFormat === GeometryFormat.WKT) {
-        const extract = extractSridFromWkt(geom);
-        cleanedGeom = extract.geom;
-        if (extract.srid) {
-          opts.dataProjection = extract.srid;
-        }
-      }
-      const feature = format.readFeature(cleanedGeom, opts);
-      feature.setProperties({ ...item });
-
-      return feature;
-    })
-    .filter(f => f !== undefined);
   return features;
 };
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/mapUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/mapUtil.tsx
@@ -135,7 +135,8 @@ export const dataRecordsToOlFeatures = (
   geomColumn: string,
   geomFormat: GeometryFormat.WKB | GeometryFormat.WKT,
 ) => {
-  const format: WKB | WKT = geomFormat === GeometryFormat.WKT ? new WKT() : new WKB();
+  const format: WKB | WKT =
+    geomFormat === GeometryFormat.WKT ? new WKT() : new WKB();
   const features: Feature[] = [];
   const defaultOpts: any = { featureProjection: 'EPSG:3857' };
   const defaultWktOpts: any = {


### PR DESCRIPTION
- Reuse parsed OpenLayers features to avoid repeated geometry parsing
- Fit map from existing features instead of re-parsing records
- Simplify feature construction in dataRecordsToOlFeatures

fix(cartodiagram): avoid repeated geometry parsing

### SUMMARY
Reuse parsed OpenLayers features for WKB/WKT geometries to avoid re-parsing on render and fit operations. This reduces repeated geometry parsing when polygon layers are large.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (performance-only change)
Before
![Slow-superset](https://github.com/user-attachments/assets/c9860014-e07f-427c-a3e1-5e4b7841b560)
After
![faster-superset](https://github.com/user-attachments/assets/2a8d5ffc-88f1-4721-a684-4d0d5e4a1665)


### TESTING INSTRUCTIONS
1. Open a Thematic Map (Cartodiagram) chart using a large polygon layer (WKB/WKT).
2. Interact with the chart (load, zoom, apply time filter if used).
3. Observe improved responsiveness and no regressions in rendering.

Using 

### ADDITIONAL INFORMATION
- [ ] Has associated issue: TODO (add if applicable, e.g., Fixes #NNNNN)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Funding: This work was funded by the Région Hauts-de-France (France).

link to https://github.com/apache/superset/issues/37843