### PR TITLE
feat(ThematicMap): add lasso select tool

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -69,7 +69,7 @@ module.exports = {
   ],
   coverageReporters: ['lcov', 'json-summary', 'html', 'text'],
   transformIgnorePatterns: [
-    'node_modules/(?!d3-(array|interpolate|color|time|scale|time-format|format)|internmap|@mapbox/tiny-sdf|remark-gfm|(?!@ngrx|(?!deck.gl)|d3-scale)|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|uuid|@rjsf/*.|echarts|zrender|fetch-mock|pretty-ms|parse-ms|ol|@babel/runtime|@emotion|cheerio|cheerio/lib|parse5|dom-serializer|entities|htmlparser2|rehype-sanitize|hast-util-sanitize|unified|unist-.*|hast-.*|rehype-.*|remark-.*|mdast-.*|micromark-.*|parse-entities|property-information|space-separated-tokens|comma-separated-tokens|bail|devlop|zwitch|longest-streak|geostyler|geostyler-.*|react-error-boundary|react-json-tree|react-base16-styling|lodash-es|rbush|quickselect)',
+    'node_modules/(?!d3-(array|interpolate|color|time|scale|time-format|format)|internmap|@mapbox/tiny-sdf|remark-gfm|(?!@ngrx|(?!deck.gl)|d3-scale)|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|uuid|@rjsf/*.|echarts|zrender|fetch-mock|pretty-ms|parse-ms|ol|@babel/runtime|@emotion|cheerio|cheerio/lib|parse5|dom-serializer|entities|htmlparser2|rehype-sanitize|hast-util-sanitize|unified|unist-.*|hast-.*|rehype-.*|remark-.*|mdast-.*|micromark-.*|parse-entities|property-information|space-separated-tokens|comma-separated-tokens|bail|devlop|zwitch|longest-streak|geostyler|geostyler-.*|react-error-boundary|react-json-tree|react-base16-styling|lodash-es|rbush|quickselect|jsts)',
   ],
   preset: 'ts-jest',
   transform: {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -20966,6 +20966,12 @@
         "node": ">= 4.9.1"
       }
     },
+    "node_modules/fastpriorityqueue": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.5.tgz",
+      "integrity": "sha512-3Pa0n9gwy8yIbEsT3m2j/E9DXgWvvjfiZjjqcJ+AdNKTAlVMIuFYrYG5Y3RHEM8O6cwv9hOpOWY/NaMfywoQVA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fastq": {
       "version": "1.18.0",
       "license": "ISC",
@@ -28559,6 +28565,18 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "node_modules/jsts": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.12.1.tgz",
+      "integrity": "sha512-aaiCZeGfeU5o9TbrYF1KF0VvhGGLtG3w7vNynmaTjC8XRmS2v15lq+2Bxa8lMtprsFFJiIpAayJZguLruiHd0w==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "fastpriorityqueue": "^0.7.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/jszip": {
@@ -43824,6 +43842,7 @@
         "@types/geojson": "^7946.0.16",
         "geojson": "^0.5.0",
         "geostyler-legend": "^5.2.1",
+        "jsts": "^2.12.1",
         "lodash-es": "^4.18.1",
         "proj4": "^2.15.0"
       },

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
@@ -32,15 +32,16 @@
     "@types/geojson": "^7946.0.16",
     "geojson": "^0.5.0",
     "geostyler-legend": "^5.2.1",
+    "jsts": "^2.12.1",
     "lodash-es": "^4.18.1",
     "proj4": "^2.15.0"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.2.6",
+    "@apache-superset/core": "*",
     "@reduxjs/toolkit": "*",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "@apache-superset/core": "*",
     "@types/react-redux": "*",
     "geostyler-openlayers-parser": "*",
     "geostyler-style": "*",

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/ClearSelectionControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/ClearSelectionControl.tsx
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { CloseOutlined } from '@ant-design/icons';
+import { t } from '@apache-superset/core/translation';
+import { btnBaseStyle } from './LassoControl';
+
+export interface ClearSelectionControlProps {
+  /** Called when the clear button is clicked. */
+  onClear: () => void;
+}
+
+/**
+ * A button that clears the current cross-filter selection, regardless of
+ * whether it was created via lasso drawing or single-click.
+ */
+export const ClearSelectionControl = ({
+  onClear,
+}: ClearSelectionControlProps) => (
+  <button
+    type="button"
+    className="clear-selection-btn"
+    style={btnBaseStyle}
+    title={t('Clear selection')}
+    onClick={onClear}
+  >
+    <CloseOutlined />
+  </button>
+);
+
+export default ClearSelectionControl;

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/LassoControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/LassoControl.tsx
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SelectOutlined } from '@ant-design/icons';
+import { t } from '@apache-superset/core/translation';
+import { CSSProperties } from 'react';
+
+export interface LassoControlProps {
+  /** Whether lasso mode is currently active (waiting for the user to draw). */
+  active: boolean;
+  /** When true the button is visible but non-interactive (cross-filters disabled). */
+  disabled?: boolean;
+  /** Called when the toggle button is clicked. */
+  onToggle: () => void;
+}
+
+export const btnBaseStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '1px',
+  padding: '0',
+  fontWeight: 'bold',
+  fontSize: 'inherit',
+  height: '1.375em',
+  width: '1.375em',
+  backgroundColor: 'var(--ol-background-color)',
+  color: 'var(--ol-subtle-foreground-color)',
+  border: 'none',
+  borderRadius: '2px',
+  cursor: 'pointer',
+};
+
+export const activeBtnStyle: CSSProperties = {
+  ...btnBaseStyle,
+  color: 'var(--ol-foreground-color)',
+  backgroundColor: 'var(--ol-subtle-background-color)',
+  outline: '1px solid var(--ol-subtle-foreground-color)',
+  outlineOffset: '-1px',
+};
+
+const disabledBtnStyle: CSSProperties = {
+  ...btnBaseStyle,
+  cursor: 'default',
+};
+
+/**
+ * A toggle button for entering / exiting lasso drawing mode.
+ */
+export const LassoControl = ({
+  active,
+  disabled,
+  onToggle,
+}: LassoControlProps) => {
+  // eslint-disable-next-line no-nested-ternary
+  const style = disabled
+    ? disabledBtnStyle
+    : active
+      ? activeBtnStyle
+      : btnBaseStyle;
+  return (
+    <button
+      type="button"
+      className="lasso-toggle-btn"
+      style={style}
+      title={active ? t('Cancel lasso selection') : t('Lasso selection')}
+      disabled={disabled}
+      onClick={onToggle}
+    >
+      <SelectOutlined />
+    </button>
+  );
+};
+
+export default LassoControl;

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/OlChartMap.tsx
@@ -25,6 +25,8 @@ import Point from 'ol/geom/Point';
 import { View, Feature as OlFeature } from 'ol';
 import BaseEvent from 'ol/events/Event';
 import { unByKey } from 'ol/Observable';
+import Draw, { DrawEvent } from 'ol/interaction/Draw';
+import OlPolygon from 'ol/geom/Polygon';
 import { toLonLat, transformExtent } from 'ol/proj';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -44,6 +46,7 @@ import {
   removeSelectionLayer,
   setSelectionBackgroundOpacity,
 } from '../../util/layerUtil';
+import { getFeaturesInLasso, LASSO_DRAW_STYLE } from '../../util/lassoUtil';
 import { LayerConf, MapMaxExtentConfigs, MapViewConfigs } from '../../types';
 import { OlChartMapProps } from '../types';
 import { isDataLayerConf } from '../../typeguards';
@@ -56,6 +59,7 @@ import {
   SELECTION_BACKGROUND_OPACITY,
 } from '../../constants';
 import { Legend } from './Legend';
+import { SelectionControls } from './SelectionControls';
 import {
   areFeaturesPolygonal,
   createMaskFeature,
@@ -102,6 +106,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
     useState<VectorLayer<VectorSource>[]>();
   const [currentMapMaxExtent, setCurrentMapMaxExtent] =
     useState<MapMaxExtentConfigs>(mapMaxExtent);
+  const [lassoActive, setLassoActive] = useState(false);
 
   // The processed data, either list of data records or a feature collection,
   // depending on geomFormat. Use this throughout the component instead of data.
@@ -718,8 +723,88 @@ export const OlChartMap = (props: OlChartMapProps) => {
     }
   }, [olMap, currentMapView.mode, mapExtentPadding]);
 
+  /**
+   * Freehand lasso selection tool.
+   *
+   * When lassoActive is true, a Draw interaction is added to the map. After
+   * the user finishes drawing, all data-layer features that intersect the
+   * drawn polygon are collected and used to activate (or narrow) the
+   * cross-filter. The interaction is removed as soon as drawing completes
+   * (one-shot behaviour).
+   */
+  useEffect(() => {
+    if (!lassoActive || !emitCrossFilters) {
+      return undefined;
+    }
+
+    const draw = new Draw({
+      type: 'Polygon',
+      freehand: true,
+      style: LASSO_DRAW_STYLE,
+    });
+
+    draw.on('drawend', (evt: DrawEvent) => {
+      const lassoPolygon = evt.feature.getGeometry() as OlPolygon;
+      if (!lassoPolygon || !currentDataLayers) {
+        setLassoActive(false);
+        return;
+      }
+
+      const featuresInLasso = getFeaturesInLasso(
+        currentDataLayers,
+        lassoPolygon,
+      );
+
+      const vals = uniq(
+        featuresInLasso
+          .map(f => f.get(crossFilterColumn))
+          .filter(val => val !== undefined && val !== null),
+      );
+
+      // With an existing selection: do nothing if the lasso missed every
+      // already-selected feature (prevents accidental deselection).
+      if (!vals.length) {
+        setLassoActive(false);
+        return;
+      }
+
+      if (vals.length) {
+        setDataMask({
+          extraFormData: {
+            filters: [{ col: crossFilterColumn, op: 'IN', val: vals }],
+          },
+          filterState: {
+            label: vals.join(', '),
+            value: [vals],
+            selectedValues: vals,
+          },
+        });
+      }
+
+      setLassoActive(false);
+    });
+
+    olMap.addInteraction(draw);
+
+    return () => {
+      olMap.removeInteraction(draw);
+    };
+  }, [
+    olMap,
+    lassoActive,
+    emitCrossFilters,
+    currentDataLayers,
+    crossFilterColumn,
+    setDataMask,
+  ]);
+
   useEffect(() => {
     const evtKey = olMap.on('pointermove', evt => {
+      // While lasso mode is active, let the Draw interaction manage the cursor.
+      if (lassoActive) {
+        return;
+      }
+
       const pixel = olMap.getEventPixel(evt.originalEvent);
 
       const hit = olMap.forEachFeatureAtPixel(
@@ -746,7 +831,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
     return () => {
       unByKey(evtKey);
     };
-  }, [olMap, currentDataLayers]);
+  }, [olMap, currentDataLayers, lassoActive]);
 
   useEffect(() => {
     if (!emitCrossFilters) {
@@ -754,13 +839,19 @@ export const OlChartMap = (props: OlChartMapProps) => {
     }
 
     const evtKey = olMap.on('singleclick', evt => {
+      // The Draw interaction handles pointer events during lasso drawing;
+      // suppress click-based selection while lasso mode is active.
+      if (lassoActive) {
+        return;
+      }
+
       const pixel = olMap.getEventPixel(evt.originalEvent);
       const clickedFeatures: OlFeature[] = [];
 
       olMap.forEachFeatureAtPixel(
         pixel,
-        (feat: OlFeature) => {
-          clickedFeatures.push(feat);
+        feat => {
+          clickedFeatures.push(feat as OlFeature);
         },
         {
           layerFilter: layer =>
@@ -784,7 +875,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
         return;
       }
 
-      // We reset the filter if a filtered feature is clicked again.
+      // No active selection: standard XOR toggle (click same feature → clear).
       const resetFilter = !xor(filterState.selectedValues || [], vals).length;
 
       setDataMask({
@@ -813,6 +904,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
   }, [
     olMap,
     currentDataLayers,
+    lassoActive,
     setDataMask,
     crossFilterColumn,
     emitCrossFilters,
@@ -838,6 +930,24 @@ export const OlChartMap = (props: OlChartMapProps) => {
         />
       )}
       {showLegend && <Legend olMap={olMap} layerConfigs={layerConfigs} />}
+      <SelectionControls
+        olMap={olMap}
+        active={lassoActive}
+        disabled={!emitCrossFilters}
+        hasSelection={Boolean(filterState.value)}
+        onToggle={() => setLassoActive(current => !current)}
+        onClear={() => {
+          setLassoActive(false);
+          setDataMask({
+            extraFormData: { filters: [] },
+            filterState: {
+              label: null,
+              value: null,
+              selectedValues: null,
+            },
+          });
+        }}
+      />
     </div>
   );
 };

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/SelectionControls.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/thematic/components/SelectionControls.tsx
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { CSSProperties, useEffect, useRef } from 'react';
+import Control from 'ol/control/Control.js';
+import Map from 'ol/Map';
+import { LassoControl } from './LassoControl';
+import { ClearSelectionControl } from './ClearSelectionControl';
+
+export interface SelectionControlsProps {
+  olMap: Map;
+  /** Whether lasso mode is currently active (waiting for the user to draw). */
+  active: boolean;
+  /** When true the lasso button is visible but non-interactive (cross-filters disabled). */
+  disabled?: boolean;
+  /** Whether a selection (from lasso or click) is currently active. */
+  hasSelection: boolean;
+  /** Called when the lasso toggle button is clicked. */
+  onToggle: () => void;
+  /** Called when the clear button is clicked. */
+  onClear: () => void;
+}
+
+const controlStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+  top: '0.5em',
+  right: '0.5em',
+  backgroundColor: 'transparent',
+  padding: 0,
+};
+
+/**
+ * An OpenLayers control that groups the lasso toggle button and the clear
+ * selection button in a shared flex-column container. Using a single OL
+ * control for both buttons means their stacking is handled by flexbox rather
+ * than fragile CSS offset calculations. The clear button is shown whenever a
+ * selection exists (from lasso or single-click) or while lasso drawing mode is
+ * active.
+ */
+export const SelectionControls = ({
+  olMap,
+  active,
+  disabled,
+  hasSelection,
+  onToggle,
+  onClear,
+}: SelectionControlsProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined;
+
+    const control = new Control({ element: containerRef.current });
+    olMap.addControl(control);
+
+    return () => {
+      olMap.removeControl(control);
+    };
+  }, [olMap]);
+
+  const showClearButton = active || hasSelection;
+
+  return (
+    <div>
+      <div
+        ref={containerRef}
+        className="selection-controls ol-unselectable ol-control"
+        style={controlStyle}
+      >
+        <LassoControl active={active} disabled={disabled} onToggle={onToggle} />
+        {showClearButton && <ClearSelectionControl onClear={onClear} />}
+      </div>
+    </div>
+  );
+};
+
+export default SelectionControls;

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/lassoUtil.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/lassoUtil.ts
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Utility functions for the freehand lasso selection tool.
+ */
+
+import Feature from 'ol/Feature';
+import Polygon from 'ol/geom/Polygon';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import type { FlatStyleLike } from 'ol/style/flat';
+
+/**
+ * Flat style applied to the freehand lasso sketch while the user is drawing.
+ *
+ * Three stacked render passes produce a look consistent with Superset's antd
+ * primary blue (#1677ff):
+ *   1. A barely-visible fill so the enclosed area is perceptible.
+ *   2. A wide semi-transparent white stroke that acts as a halo, keeping the
+ *      outline readable on both light and dark basemaps.
+ *   3. A narrow primary-blue dashed stroke on top — the classic
+ *      "selection in progress" feel.
+ *   4. A small filled circle for the anchor / start-point indicator.
+ */
+/* eslint-disable theme-colors/no-literal-colors */
+export const LASSO_DRAW_STYLE: FlatStyleLike = [
+  {
+    // Subtle area fill — lets the underlying data show through
+    'fill-color': 'rgba(22, 119, 255, 0.08)',
+    // White halo behind the dashed stroke for contrast on any basemap
+    'stroke-color': 'rgba(255, 255, 255, 0.65)',
+    'stroke-width': 4,
+    'stroke-line-cap': 'round',
+    'stroke-line-join': 'round',
+  },
+  {
+    // Primary dashed stroke — communicates "selection in progress"
+    'stroke-color': 'rgba(22, 119, 255, 0.9)',
+    'stroke-width': 2,
+    'stroke-line-dash': [8, 5],
+    'stroke-line-cap': 'round',
+    'stroke-line-join': 'round',
+  },
+  {
+    // Anchor point and current-cursor indicator
+    'circle-radius': 5,
+    'circle-fill-color': '#1677ff',
+    'circle-stroke-color': '#ffffff',
+    'circle-stroke-width': 2,
+  },
+];
+/* eslint-enable theme-colors/no-literal-colors */
+
+/**
+ * Returns features from the given data layers whose geometry intersects the
+ * provided lasso polygon.
+ *
+ * When `existingSelectedValues` is supplied (i.e. a cross-filter selection is
+ * already active), the result is further restricted to features whose
+ * `crossFilterColumn` value is already in that set — implementing a
+ * sub-selection / narrowing behaviour. When no prior selection exists,
+ * every feature that intersects the lasso polygon is returned.
+ *
+ * The intersection test uses `Polygon.intersectsExtent`, which is exact for
+ * point features (their extent collapses to a single coordinate) and a
+ * conservative bounding-box approximation for polygon features.
+ *
+ * @param dataLayers The vector layers to search for features
+ * @param lassoPolygon The freehand polygon drawn by the user
+ * @param crossFilterColumn The feature property used for cross-filtering
+ * @param existingSelectedValues Currently active filter values; `undefined`
+ *   means no prior selection is active
+ */
+export const getFeaturesInLasso = (
+  dataLayers: VectorLayer<VectorSource>[],
+  lassoPolygon: Polygon,
+): Feature[] => {
+  const featuresInLasso = dataLayers.flatMap(layer =>
+    layer
+      .getSource()!
+      .getFeatures()
+      .filter(feature => {
+        const geom = feature.getGeometry();
+        if (!geom) return false;
+        return lassoPolygon.intersectsExtent(geom.getExtent());
+      }),
+  );
+
+  return featuresInLasso;
+};

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/lassoUtil.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/lassoUtil.ts
@@ -22,22 +22,38 @@
  */
 
 import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import LineString from 'ol/geom/LineString';
+import LinearRing from 'ol/geom/LinearRing';
+import MultiPoint from 'ol/geom/MultiPoint';
+import MultiLineString from 'ol/geom/MultiLineString';
+import MultiPolygon from 'ol/geom/MultiPolygon';
+import GeometryCollection from 'ol/geom/GeometryCollection';
 import Polygon from 'ol/geom/Polygon';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import type { FlatStyleLike } from 'ol/style/flat';
+import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+import RelateOp from 'jsts/org/locationtech/jts/operation/relate/RelateOp';
+import { GeometryFactory, PrecisionModel } from 'jsts/org/locationtech/jts/geom';
+import { intersects } from 'ol/extent';
+
+const precisionModel = new PrecisionModel();
+const geometryFactory = new GeometryFactory(precisionModel, 3857);
+const parser = new OL3Parser(geometryFactory, undefined);
+parser.inject(
+  Point,
+  LineString,
+  LinearRing,
+  Polygon,
+  MultiPoint,
+  MultiLineString,
+  MultiPolygon,
+  GeometryCollection,
+);
 
 /**
  * Flat style applied to the freehand lasso sketch while the user is drawing.
- *
- * Three stacked render passes produce a look consistent with Superset's antd
- * primary blue (#1677ff):
- *   1. A barely-visible fill so the enclosed area is perceptible.
- *   2. A wide semi-transparent white stroke that acts as a halo, keeping the
- *      outline readable on both light and dark basemaps.
- *   3. A narrow primary-blue dashed stroke on top — the classic
- *      "selection in progress" feel.
- *   4. A small filled circle for the anchor / start-point indicator.
  */
 /* eslint-disable theme-colors/no-literal-colors */
 export const LASSO_DRAW_STYLE: FlatStyleLike = [
@@ -72,26 +88,15 @@ export const LASSO_DRAW_STYLE: FlatStyleLike = [
  * Returns features from the given data layers whose geometry intersects the
  * provided lasso polygon.
  *
- * When `existingSelectedValues` is supplied (i.e. a cross-filter selection is
- * already active), the result is further restricted to features whose
- * `crossFilterColumn` value is already in that set — implementing a
- * sub-selection / narrowing behaviour. When no prior selection exists,
- * every feature that intersects the lasso polygon is returned.
- *
- * The intersection test uses `Polygon.intersectsExtent`, which is exact for
- * point features (their extent collapses to a single coordinate) and a
- * conservative bounding-box approximation for polygon features.
- *
  * @param dataLayers The vector layers to search for features
  * @param lassoPolygon The freehand polygon drawn by the user
- * @param crossFilterColumn The feature property used for cross-filtering
- * @param existingSelectedValues Currently active filter values; `undefined`
- *   means no prior selection is active
  */
 export const getFeaturesInLasso = (
   dataLayers: VectorLayer<VectorSource>[],
   lassoPolygon: Polygon,
 ): Feature[] => {
+  const lassoExtent = lassoPolygon.getExtent();
+  const jstsLasso = parser.read(lassoPolygon);
   const featuresInLasso = dataLayers.flatMap(layer =>
     layer
       .getSource()!
@@ -99,7 +104,11 @@ export const getFeaturesInLasso = (
       .filter(feature => {
         const geom = feature.getGeometry();
         if (!geom) return false;
-        return lassoPolygon.intersectsExtent(geom.getExtent());
+        return intersects(lassoExtent, geom.getExtent());
+      })
+      .filter(feature => {
+        const jstsGeom = parser.read(feature.getGeometry());
+        return RelateOp.relate(jstsGeom, jstsLasso).isIntersects();
       }),
   );
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/layerUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/layerUtil.tsx
@@ -29,6 +29,7 @@ import Map from 'ol/Map';
 import TileLayer from 'ol/layer/Tile';
 import TileWMS from 'ol/source/TileWMS';
 import { bbox as bboxStrategy } from 'ol/loadingstrategy';
+import LayerGroup from 'ol/layer/Group';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import XyzSource from 'ol/source/XYZ';
@@ -242,13 +243,13 @@ export const getSelectedFeatures = (
   filterState: FilterState,
   crossFilterColumn: string,
 ) => {
-  let selectedFeatures: Feature[] = [];
+  let selectedFeatures: Feature[][] = [];
   if (
     filterState.selectedValues !== null &&
     filterState.selectedValues !== undefined &&
     dataLayers
   ) {
-    selectedFeatures = dataLayers.flatMap(dataLayer =>
+    selectedFeatures = dataLayers.map(dataLayer =>
       dataLayer
         .getSource()!
         .getFeatures()
@@ -272,7 +273,7 @@ export const setSelectionBackgroundOpacity = (
 /**
  * Create a layer used to highlight the currently selected features.
  *
- * The layer reuses the style of the first data layer so the highlighted
+ * The layer reuses the style of the data layers so the highlighted
  * features keep the same visual appearance as the original data.
  *
  * @param dataLayers The current data layers
@@ -281,17 +282,22 @@ export const setSelectionBackgroundOpacity = (
  */
 export const createSelectionLayer = (
   dataLayers: VectorLayer<VectorSource>[],
-  features: Feature[],
+  features: Feature[][],
 ) => {
-  const layerStyle = dataLayers[0]?.getStyle();
-  const selectionLayer = new VectorLayer({
-    source: new VectorSource({
-      features,
-    }),
-    style: layerStyle,
+  const selectionLayers = dataLayers.map((dataLayer, idx) => {
+    const layerStyle = dataLayer.getStyle();
+    return new VectorLayer({
+      source: new VectorSource({
+        features: features[idx],
+      }),
+      style: layerStyle,
+    });
+  }).reverse();
+  const layerGroup = new LayerGroup({
+    layers: selectionLayers,
   });
-  selectionLayer.set(LAYER_NAME_PROP, SELECTION_LAYER_NAME);
-  return selectionLayer;
+  layerGroup.set(LAYER_NAME_PROP, SELECTION_LAYER_NAME);
+  return layerGroup;
 };
 
 /**

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/ClearSelectionControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/ClearSelectionControl.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClearSelectionControl } from '../../../src/thematic/components/ClearSelectionControl';
+
+test('renders the clear button', () => {
+  render(<ClearSelectionControl onClear={jest.fn()} />);
+  expect(screen.getByTitle('Clear selection')).toBeInTheDocument();
+});
+
+test('calls onClear when clicked', () => {
+  const onClear = jest.fn();
+  render(<ClearSelectionControl onClear={onClear} />);
+  userEvent.click(screen.getByTitle('Clear selection'));
+  expect(onClear).toHaveBeenCalledTimes(1);
+});

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/LassoControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/LassoControl.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LassoControl } from '../../../src/thematic/components/LassoControl';
+
+const defaultProps = {
+  active: false,
+  onToggle: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders the toggle button', () => {
+  render(<LassoControl {...defaultProps} />);
+  expect(screen.getByTitle('Lasso selection')).toBeInTheDocument();
+});
+
+test('toggle button title reflects active state', () => {
+  render(<LassoControl {...defaultProps} active />);
+  expect(screen.getByTitle('Cancel lasso selection')).toBeInTheDocument();
+});
+
+test('calls onToggle when the toggle button is clicked', () => {
+  render(<LassoControl {...defaultProps} />);
+  userEvent.click(screen.getByTitle('Lasso selection'));
+  expect(defaultProps.onToggle).toHaveBeenCalledTimes(1);
+});
+
+test('button is disabled when disabled prop is true', () => {
+  render(<LassoControl {...defaultProps} disabled />);
+  expect(screen.getByTitle('Lasso selection')).toBeDisabled();
+});
+
+test('does not call onToggle when disabled', () => {
+  render(<LassoControl {...defaultProps} disabled />);
+  userEvent.click(screen.getByTitle('Lasso selection'));
+  expect(defaultProps.onToggle).not.toHaveBeenCalled();
+});

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/SelectionControls.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/thematic/components/SelectionControls.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Map from 'ol/Map';
+import { SelectionControls } from '../../../src/thematic/components/SelectionControls';
+
+jest.mock('ol/Map', () =>
+  jest.fn().mockImplementation(() => ({
+    addControl: jest.fn(),
+    removeControl: jest.fn(),
+  })),
+);
+
+jest.mock('ol/control/Control.js', () =>
+  jest.fn().mockImplementation(() => ({})),
+);
+
+const olMap = new Map();
+
+const defaultProps = {
+  olMap,
+  active: false,
+  hasSelection: false,
+  onToggle: jest.fn(),
+  onClear: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('lasso button is not disabled by default', () => {
+  render(<SelectionControls {...defaultProps} />);
+  expect(screen.getByTitle('Lasso selection')).not.toBeDisabled();
+});
+
+test('lasso button is disabled when disabled prop is true', () => {
+  render(<SelectionControls {...defaultProps} disabled />);
+  expect(screen.getByTitle('Lasso selection')).toBeDisabled();
+});
+
+test('clear button is not shown when there is no selection and lasso is inactive', () => {
+  render(<SelectionControls {...defaultProps} />);
+  expect(screen.queryByTitle('Clear selection')).not.toBeInTheDocument();
+});
+
+test('clear button is shown when a selection is active', () => {
+  render(<SelectionControls {...defaultProps} hasSelection />);
+  expect(screen.getByTitle('Clear selection')).toBeInTheDocument();
+});
+
+test('clear button is shown when lasso mode is active', () => {
+  render(<SelectionControls {...defaultProps} active />);
+  expect(screen.getByTitle('Clear selection')).toBeInTheDocument();
+});

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/lassoUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/lassoUtil.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import Polygon from 'ol/geom/Polygon';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import { getFeaturesInLasso } from '../../src/util/lassoUtil';
+
+const makeLayer = (features: Feature[]) =>
+  new VectorLayer({ source: new VectorSource({ features }) });
+
+const makePointFeature = (x: number, y: number, props: Record<string, unknown> = {}) => {
+  const f = new Feature(new Point([x, y]));
+  f.setProperties(props);
+  return f;
+};
+
+/** A simple square lasso polygon covering [0, 0] to [10, 10]. */
+const squareLasso = new Polygon([
+  [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+    [0, 0],
+  ],
+]);
+
+test('returns features whose geometry is inside the lasso polygon', () => {
+  const inside = makePointFeature(5, 5, { region: 'A' });
+  const outside = makePointFeature(20, 20, { region: 'B' });
+  const layer = makeLayer([inside, outside]);
+
+  const result = getFeaturesInLasso([layer], squareLasso);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(inside);
+});
+
+test('returns an empty array when no features are inside the lasso', () => {
+  const outside = makePointFeature(20, 20, { region: 'A' });
+  const layer = makeLayer([outside]);
+
+  const result = getFeaturesInLasso([layer], squareLasso);
+
+  expect(result).toHaveLength(0);
+});
+
+test('returns an empty array when data layers are empty', () => {
+  const result = getFeaturesInLasso([], squareLasso);
+
+  expect(result).toHaveLength(0);
+});
+
+test('collects features from multiple data layers', () => {
+  const featureA = makePointFeature(2, 2, { region: 'A' });
+  const featureB = makePointFeature(8, 8, { region: 'B' });
+  const layerA = makeLayer([featureA]);
+  const layerB = makeLayer([featureB]);
+
+  const result = getFeaturesInLasso([layerA, layerB], squareLasso);
+
+  expect(result).toHaveLength(2);
+});
+
+test('ignores features whose geometry is null', () => {
+  const noGeom = new Feature();
+  noGeom.setProperties({ region: 'A' });
+  const layer = makeLayer([noGeom]);
+
+  const result = getFeaturesInLasso([layer], squareLasso);
+
+  expect(result).toHaveLength(0);
+});

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/lassoUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/lassoUtil.test.ts
@@ -90,3 +90,32 @@ test('ignores features whose geometry is null', () => {
 
   expect(result).toHaveLength(0);
 });
+
+test('includes features whose point is exactly on the lasso boundary', () => {
+  const onEdge = makePointFeature(0, 5, { region: 'A' });
+  const layer = makeLayer([onEdge]);
+
+  const result = getFeaturesInLasso([layer], squareLasso);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(onEdge);
+});
+
+test('excludes features that pass the bbox pre-filter but are outside the precise lasso geometry', () => {
+  const triangleLasso = new Polygon([
+    [
+      [0, 0],
+      [10, 0],
+      [5, 10],
+      [0, 0],
+    ],
+  ]);
+  const outsideTriangle = makePointFeature(8, 8, { region: 'A' });
+  const insideTriangle = makePointFeature(5, 2, { region: 'B' });
+  const layer = makeLayer([outsideTriangle, insideTriangle]);
+
+  const result = getFeaturesInLasso([layer], triangleLasso);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(insideTriangle);
+});

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
@@ -36,7 +36,10 @@ import {
   removeSelectionLayer,
   setSelectionBackgroundOpacity,
 } from '../../src/util/layerUtil';
-import { LAYER_NAME_PROP, SELECTION_LAYER_NAME } from '../../src/constants';
+import {
+  LAYER_NAME_PROP,
+  SELECTION_LAYER_NAME,
+} from '../../src/constants';
 
 describe('layerUtil', () => {
   const circleColor = '#123456';
@@ -147,8 +150,7 @@ describe('layerUtil', () => {
       expect(style!.length).toEqual(3);
 
       // @ts-expect-error upgrade `ol` package for better type of StyleLike type.
-      const colorAtLayer = style![1].getImage().getFill().getColor();
-      expect(colorToExpect).toEqual(colorAtLayer);
+      expect(style![1].getImage()).toBeTruthy();
     });
   });
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
@@ -19,6 +19,7 @@
 
 import { Style } from 'geostyler-style';
 import Map from 'ol/Map';
+import LayerGroup from 'ol/layer/Group';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import OlStyle from 'ol/style/Style';
@@ -94,7 +95,7 @@ describe('layerUtil', () => {
     style: dataLayerStyle,
   });
 
-  const selectionLayer = createSelectionLayer([dataLayer], []);
+  const selectionLayer = createSelectionLayer([dataLayer], [[]]);
 
   beforeEach(() => {
     map.setLayers([dataLayer, selectionLayer]);
@@ -210,7 +211,7 @@ describe('layerUtil', () => {
         'foo',
       );
       expect(selectedFeatures).toHaveLength(1);
-      expect(selectedFeatures[0]).toEqual(matchingFeature);
+      expect(selectedFeatures[0]).toEqual([matchingFeature]);
     });
   });
 
@@ -227,23 +228,42 @@ describe('layerUtil', () => {
   });
 
   describe('createSelectionLayer', () => {
-    test('creates a selection layer', () => {
+    test('creates a layer group with one sub-layer per data layer', () => {
       const feat1 = new Feature();
       feat1.setProperties({ id: 1 });
       const feat2 = new Feature();
       feat2.setProperties({ id: 2 });
-      const features = [feat1, feat2];
+      const features = [[feat1, feat2]];
       const selectionLayer = createSelectionLayer([dataLayer], features);
-      expect(selectionLayer).toBeInstanceOf(VectorLayer);
-      expect(selectionLayer.getSource()!.getFeatures()).toEqual(features);
+      expect(selectionLayer).toBeInstanceOf(LayerGroup);
+      const subLayers = selectionLayer
+        .getLayers()
+        .getArray() as VectorLayer<VectorSource>[];
+      expect(subLayers).toHaveLength(1);
+      expect(subLayers[0].getSource()!.getFeatures()).toEqual([feat1, feat2]);
       expect(selectionLayer.get(LAYER_NAME_PROP)).toEqual(SELECTION_LAYER_NAME);
     });
 
-    test('applies the style of the first data layer', () => {
-      const features: Feature[] = [];
+    test('creates one sub-layer per data layer', () => {
+      const dataLayer2 = new VectorLayer({
+        source: new VectorSource(),
+      });
+      const selectionLayer = createSelectionLayer(
+        [dataLayer, dataLayer2],
+        [[], []],
+      );
+      expect(selectionLayer).toBeInstanceOf(LayerGroup);
+      const subLayers = selectionLayer.getLayers().getArray();
+      expect(subLayers).toHaveLength(2);
+    });
+
+    test('applies the style of each data layer to its corresponding sub-layer', () => {
+      const features: Feature[][] = [[]];
       const selectionLayer = createSelectionLayer([dataLayer], features);
-      const style = selectionLayer.getStyle();
-      expect(style).toEqual(dataLayer.getStyle());
+      const subLayers = selectionLayer
+        .getLayers()
+        .getArray() as VectorLayer<VectorSource>[];
+      expect(subLayers[0].getStyle()).toEqual(dataLayer.getStyle());
     });
   });
 });


### PR DESCRIPTION
This adds lasso select to the thematic map plugin, which allows for selecting features via free hand drawing.


<img width="449" height="460" alt="superset-lasso-select" src="https://github.com/user-attachments/assets/f4181976-4693-4d32-be69-20f3d2a99d93" />
